### PR TITLE
:bug: [fix a bug] =>  fix alias for docker compose

### DIFF
--- a/.zsh/docker_alias.zsh
+++ b/.zsh/docker_alias.zsh
@@ -36,7 +36,6 @@ function dlog() {
 
 
 ### Docker Compose
-alias dcm='docker compose '
 alias dcmd='docker compose down'
 
 function dcmu() {


### PR DESCRIPTION
`dcmd` alias does work because `dcm` alias effect on this command. I deleted `dcm`.