### PR TITLE
:necktie: [add business logic] =>  add show_git_alias command

### DIFF
--- a/.zsh/basic_function.zsh
+++ b/.zsh/basic_function.zsh
@@ -1,0 +1,7 @@
+function show_git_alias() {
+    echo -e "Alias\tCommand\n----\t-------"
+    while IFS=',' read -r alias command
+    do
+        echo -e "${alias}\t${command}"
+    done < $HOME/.zsh/doc/git_alias.csv | column -t
+}

--- a/.zsh/doc/git_alias.csv
+++ b/.zsh/doc/git_alias.csv
@@ -1,0 +1,11 @@
+gad,git add .
+gamd,git commit --amend
+gbr,git branch
+gbrr,git branch -r
+gcb,git checkout -b 
+gcr,git rm -r --cached
+gpull,git pull origin
+gpush,git push origin
+greset,git reset
+gst,git status
+gsw,git switch 

--- a/.zsh/git_alias.zsh
+++ b/.zsh/git_alias.zsh
@@ -1,10 +1,32 @@
-# GIT ALIAS SETTING
-alias gst='git status'
-alias gbr='git branch'
-alias gbrr='git branch -r'
+# Add all changes in working directory to the staging area
 alias gad='git add .'
-alias gsw='git switch '
-alias gcb='git checkout -b '
-alias gpush='git push origin'
-alias gpull='git pull origin'
+
+# Amend the most recent commit
 alias gamd='git commit --amend'
+
+# List all local branches
+alias gbr='git branch'
+
+# List all remote branches
+alias gbrr='git branch -r'
+
+# Create a new branch and switch to it
+alias gcb='git checkout -b '
+
+# Remove files from the index (staging area)
+alias gcr='git rm -r --cached'
+
+# Fetch from and integrate with another repository or a local branch (short for 'git pull origin')
+alias gpull='git pull origin'
+
+# Update remote refs along with associated objects (short for 'git push origin')
+alias gpush='git push origin'
+
+# Reset current HEAD to the specified state
+alias greset='git reset'
+
+# Show the working tree status
+alias gst='git status'
+
+# Switch to another branch
+alias gsw='git switch '

--- a/make_csv.sh
+++ b/make_csv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Remove lines starting with '#'
+grep -v '^#' .zsh/git_alias.zsh | \
+# Remove 'alias ' at the start of each line
+perl -pe 's/^alias //' | \
+# Replace '=' with ','
+perl -pe "s/='/,/" | \
+# Remove trailing quote
+perl -pe "s/'$//" | \
+# Remove blank lines
+grep -v '^$' > .zsh/doc/git_alias.csv


### PR DESCRIPTION
I added super command `show_git_alias` which who our alias for git. This is first step to show our alias. I am going to expand for other command.

- you can get alias infromation bu just running `show_git_alias`
- to make csv file for these alias, I create `make_csv.sh`, but its name will change `make_csv/for_git_alias.sh`

![picture in development env](https://github.com/shunsock/zshian/assets/84004458/64a81ed4-6d2f-4c1c-b21a-1ad80158c8f8)
